### PR TITLE
Migrated from MapFlow PR #1437: Scribe: Fix broken links in A3_PROJECT/B2_QUALITY

### DIFF
--- a/docs/A3_PROJECT/B2_QUALITY/CURRENT_CODE_AUDIT_2026-03-30.md
+++ b/docs/A3_PROJECT/B2_QUALITY/CURRENT_CODE_AUDIT_2026-03-30.md
@@ -1,6 +1,6 @@
 # Intensiver Code-Audit-Bericht (Stand 30. März 2026)
 
-**Methodik:** 
+**Methodik:**
 1. Unabhängige statische Analyse (`cargo clippy`, `cargo audit`, Architektur-Scan) des aktuellen `main` Branches.
 2. Abgleich und Konsolidierung mit historischen Audit-Berichten (Stand 23.03.2026), um blinde Flecken der Automatisierung zu decken.
 


### PR DESCRIPTION
Migrated from https://github.com/MrLongNight/MapFlow/pull/1437 during canonical repo cutover. Original head branch: docs/fix-broken-links-b2-quality-4299544071660596922. Original base branch: main. Review the original PR in the legacy MapFlow repo for the full Jules-generated description and discussion context before archive.