### PR TITLE
ci: exclude .vscode/skills from markdownlint to unblock PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,3 @@ monitor-jules-sessions.ps1
 .paperclip-home/
 ops/paperclip/
 scripts/paperclip/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
           - 'MD041'
         files: \.(md|markdown)$
         # Exclude existing problematic files (legacy)
-        exclude: ^(CHANGELOG\.md|ROADMAP\.md|.*\.patch|\.jules/.*|\.agent/.*|docs/.*|crates/vendor/.*|\.paperclip-home/.*)$
+        exclude: ^(CHANGELOG\.md|ROADMAP\.md|.*\.patch|\.jules/.*|\.agent/.*|\.vscode/skills/.*|docs/.*|crates/vendor/.*|\.paperclip-home/.*)$
 
   # ═══════════════════════════════════════════════════════════════
   # SECURITY: SECRET DETECTION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- 2026-04-14: ci: Exclude .vscode/skills from markdownlint to unblock PRs (#245)
 - 2026-04-12: perf: Bolt: Performance-Optimierung durch Vermeidung redundanter String-Allokationen in UI-Schleifen (#221)
 - 2026-04-12: feat: UI: Theme-aware colors in Node Editor (#222)
 - 2026-04-12: fix: Sentinel: Fix DoS panic on float sorting with NaN (#223)


### PR DESCRIPTION
Excludes \`.vscode/skills/\` from markdownlint-fix pre-commit hook. The paperclip reference docs have legacy MD violations. This unblocks PRs #241-#244 which all have GitHub CI passing but are blocked by pre-commit.ci.