### PR TITLE
chore: fix Phase 8.1 attribution in ROADMAP.md (VOR-37)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,13 +10,13 @@ Ship Vorce toward a production-ready 1.0 by improving render stability, media pi
 - [ ] **VOR-24:** Set up cargo-deb for Linux (.deb) packaging
 - [ ] **VOR-25:** Evaluate AppImage vs Flatpak for Linux distribution
 
-### Phase 8.1: NDI Video Streaming [Ready for Delivery]
+### Phase 8.1: NDI Video Streaming [Delivered — code on main]
 - [x] **VOR-26:** Scaffolding of Vorce-ndi crate and grafton-ndi integration
-- [x] **VOR-27:** Implementation of NDI Sender (wgpu Texture to NDI) (PR #307)
-- [x] **VOR-28:** Implementation of NDI Receiver (NDI to Fullscreen) (PR #307)
-- [x] **VOR-29:** Multi-source NDI discovery (NDI Finder) (PR #307)
+- [x] **VOR-27:** Implementation of NDI Sender (wgpu Texture to NDI) (code merged to main via cleanup wave; PR #307 closed unmerged)
+- [x] **VOR-28:** Implementation of NDI Receiver (NDI to Fullscreen) (code merged to main via cleanup wave; PR #307 closed unmerged)
+- [x] **VOR-29:** Multi-source NDI discovery (NDI Finder) (code merged to main via cleanup wave; PR #307 closed unmerged)
 - [x] **VOR-30:** Benchmarking and latency optimization for NDI [<100ms] (PR #336, #339)
-- [x] **VOR-32:** Ben: Drive Phase 8.1 NDI Delivery (PR #307)
+- [x] **VOR-32:** Ben: Drive Phase 8.1 NDI Delivery (code on main; PR #307 closed unmerged)
 
 ### Phase 9: Repository Health & CI Stabilization [In Progress]
 - [x] **VOR-33:** Consolidated 14 pending PRs into unified integration branch


### PR DESCRIPTION
## Summary

Fixes stale delivery artifact from the Jules cleanup wave (VOR-37).

### Changes
- Updated Phase 8.1 status from 'Ready for Delivery' to 'Delivered — code on main'
- Corrected PR attribution for VOR-27/28/29/32: PR #307 was **closed unmerged**; NDI code reached main via the Jules cleanup wave (direct squash/cherry-pick into main)
- No functional code changes

### Context
VOR-37 (Artifact-Hygiene) identified that ROADMAP.md incorrectly attributed Phase 8.1 delivery to PR #307, which was closed without merging. The actual NDI implementation is present on main.